### PR TITLE
Update README.md with Visual Studio Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ let g:neoformat_enabled_erlang = ['steamroller']
 autocmd BufWritePre rebar.config,*.[he]rl,*.app.src Neoformat steamroller
 ```
 
+### Visual Studio Code
+
+You can use steamroller from Visual Studio Code with the [Erlang Formatter](https://marketplace.visualstudio.com/items?itemName=szTheory.erlang-formatter) extension.
+
 ## CI
 
 To check that code is properly formatted as part of your CI:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ autocmd BufWritePre rebar.config,*.[he]rl,*.app.src Neoformat steamroller
 
 ### Visual Studio Code
 
-You can use steamroller from Visual Studio Code with the [Erlang Formatter](https://marketplace.visualstudio.com/items?itemName=szTheory.erlang-formatter) extension.
+You can use steamroller from Visual Studio Code with the
+[Erlang Formatter](https://marketplace.visualstudio.com/items?itemName=szTheory.erlang-formatter)
+extension created by [szTheory](https://github.com/szTheory).
 
 ## CI
 


### PR DESCRIPTION
Added [new VS Code extension](https://github.com/szTheory/vsc-erlang-formatter). The extension itself works great at a basic level, so thanks again for your hard work to make this possible! There are a couple things I'd like to improve in the VS Code extension for a better user experience.

- Performance: Investigate piping the output from steamroller STDOUT directly to VS Code and replacing its internal buffer rather than steamroller overwriting the file which takes almost 1.5-2 seconds to refresh in the VS Code UI after hitting save. The main Elixir extension does this and it's very fast.
- Friendly error message UI: Integrate with error messages from steamroller for detailed error messages.