### PR TITLE
Handle steamroller_worker_sup already started

### DIFF
--- a/src/steamroller_prv.erl
+++ b/src/steamroller_prv.erl
@@ -118,7 +118,11 @@ find_dir_files(Dir) ->
 
 format_files(Files, Opts) ->
     {Headers, OtherFiles} = steamroller_utils:split_header_files(Files),
-    {ok, _} = steamroller_worker_sup:start_link(Opts),
+    ok =
+        case steamroller_worker_sup:start_link(Opts) of
+            {ok, _} -> ok;
+            {error, {already_started, _}} -> ok
+        end,
     J = proplists:get_value(j, Opts, ?DEFAULT_J_FACTOR),
     case J of
         J when J > 1 ->


### PR DESCRIPTION
I get an error when I run steamroll on my project.
I don't know why steamroller_worker_sup would get started twice but ignoring the error allows streamroll to complete successfully.