### PR TITLE
Treat inputs the same

### DIFF
--- a/src/steamroller_prv.erl
+++ b/src/steamroller_prv.erl
@@ -8,6 +8,7 @@
 -define(DEPS, [app_discovery]).
 -define(FILE_KEY, steamroll_file).
 -define(DIR_KEY, steamroll_dir).
+-define(APP_KEY, steamroll_app).
 -define(INCLUDES_KEY, steamroll_includes).
 -define(DEFAULT_INPUTS, ["rebar.config", "{src,test}/**/*.{[he]rl,app.src}"]).
 -define(DEFAULT_J_FACTOR, 1).
@@ -31,6 +32,7 @@ init(State) ->
           [
             {?FILE_KEY, $f, "file", binary, "File name to format."},
             {?DIR_KEY, $d, "dir", string, "Dir name to format."},
+            {?APP_KEY, $a, "app", string, "App name to format."},
             {?INCLUDES_KEY, $i, "includes", string, "Wildcard includes path."},
             {j, $j, undefined, integer, "J Factor."},
             {check, $c, "check", undefined, "Check code formatting without changing anything."}
@@ -68,7 +70,9 @@ do(State) ->
         true ->
             Fs = proplists:get_all_values(?FILE_KEY, Opts),
             Ds = proplists:get_all_values(?DIR_KEY, Opts),
-            Fs ++ directory_files(Ds, Opts);
+            As = proplists:get_all_values(?APP_KEY, Opts),
+            Apps = find_app_infos(As, State),
+            Fs ++ directory_files(Ds, Opts) ++ application_files(Apps, Opts);
         false ->
             Apps = case rebar_state:current_app(State) of
                        undefined ->
@@ -105,6 +109,10 @@ format_error(Reason) -> io_lib:format("Steamroller Error: ~p", [Reason]).
 %% ===================================================================
 %% Internal
 %% ===================================================================
+
+find_app_infos(As, State) ->
+    [A || A <- rebar_state:project_apps(State),
+          lists:member(rebar_app_info:name(A), As)].
 
 application_files([], _) ->
     [];

--- a/src/steamroller_prv.erl
+++ b/src/steamroller_prv.erl
@@ -113,14 +113,12 @@ format_error(Reason) -> io_lib:format("Steamroller Error: ~p", [Reason]).
 %% ===================================================================
 
 dirs_for_apps(As, State) ->
-    [rebar_app_info:dir(A)
-     || A <- rebar_state:project_apps(State),
-        lists:member(rebar_app_info:name(A), As)].
+  [rebar_app_info:dir(A)
+   || A <- rebar_state:project_apps(State),
+      lists:member(rebar_app_info:name(A), As)].
 
-directory_files([], _Opts) ->
-    [];
-directory_files([D|Ds], Opts) ->
-    find_dir_files(D, Opts) ++ directory_files(Ds, Opts).
+directory_files(Ds, Opts) ->
+  lists:flatmap(fun (D) -> find_dir_files(D, Opts) end, Ds).
 
 find_dir_files(Dir, Opts) ->
   Inputs = proplists:get_value(inputs, Opts, ?DEFAULT_INPUTS),

--- a/src/steamroller_prv.erl
+++ b/src/steamroller_prv.erl
@@ -82,7 +82,7 @@ do(State) ->
                            [AppInfo]
                    end,
             AppDirs = [rebar_app_info:dir(A) || A <- Apps],
-            directory_files(AppDirs, Opts)
+            directory_files(["."|AppDirs], Opts)
     end,
   case format_files(Files, Opts) of
     ok ->


### PR DESCRIPTION
When having an umbrella project then steamroll doesn't find the local rebar.config with the ?DEFAULT_INPUTS.
Documentation now states which parameters the ?DEFAULT_INPUTS is valid for.

I refactored the code to permit multiple flags for input files as well as added a `--app` flag for when you only want to format one app.

This is now possible:
`rebar3 steamroll -f rebar.config -f src/steamroller_algebra.erl -d test/`

```
===> Steamrolling file: rebar.config
===> Steamrolling file: src/steamroller_algebra.erl
===> Steamrolling file: test/steamroller_algebra_test.erl
===> Steamrolling file: test/steamroller_ast_test.erl
===> Steamrolling file: test/steamroller_formatter_test.erl
```